### PR TITLE
Add banner image to BYOND website.

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -262,6 +262,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 
 	if (!host && config && config.hostedby)
 		features += "hosted by <b>[config.hostedby]</b>"
+		features += "<img src=\"https://i.imgur.com/Tbn74rs.png\">" //Banner image
 
 	if (features)
 		s += ": [jointext(features, ", ")]"


### PR DESCRIPTION
This adds a banner image to the server listing on the BYOND website - just a bit of pizzazz.